### PR TITLE
Pure HTML drag event handling

### DIFF
--- a/packages/interaction/src/dnd/PointerDragging.ts
+++ b/packages/interaction/src/dnd/PointerDragging.ts
@@ -103,9 +103,11 @@ export class PointerDragging {
 
       if (!this.shouldIgnoreMove) {
         document.addEventListener('mousemove', this.handleMouseMove)
+        document.addEventListener('dragover', this.handleMouseMove)
       }
 
       document.addEventListener('mouseup', this.handleMouseUp)
+      document.addEventListener('dragend', this.handleMouseUp)
     }
   }
 
@@ -117,7 +119,9 @@ export class PointerDragging {
 
   handleMouseUp = (ev: MouseEvent) => {
     document.removeEventListener('mousemove', this.handleMouseMove)
+    document.removeEventListener('dragover', this.handleMouseMove)
     document.removeEventListener('mouseup', this.handleMouseUp)
+    document.removeEventListener('dragend', this.handleMouseUp)
 
     this.emitter.trigger('pointerup', this.createEventFromMouse(ev))
 


### PR DESCRIPTION
As of now, the `PointerDragging` class only listens to `mousemove` and `mouseup` to handle dragging events. However, when an element has the `"draggable"="true"` tag, these events are replaced respectively by `dragover` and `dragend`.

This commit adds new listeners for these events, allowing to track both methods of dragging without any further configuration needed.